### PR TITLE
Corrected location line and backticks to display line as code

### DIFF
--- a/content/docs/v1/setup/setup-with-sqlite.md
+++ b/content/docs/v1/setup/setup-with-sqlite.md
@@ -38,7 +38,7 @@ After that, generate a new admin account by running the following command. You w
 docker exec -it linkace_app_1 php artisan registeruser
 ```
 
-Lastly, change 'SETUP_COMPLETED=false' to 'SETUP_COMPLETED=true' in your `.env` file.
+Lastly, change `SETUP_COMPLETED=false` to `SETUP_COMPLETED=true` in your `.env` file.
 
 You can now open LinkAce in your browser and should be able to use the application.
 

--- a/content/docs/v1/setup/setup-with-sqlite.md
+++ b/content/docs/v1/setup/setup-with-sqlite.md
@@ -38,6 +38,8 @@ After that, generate a new admin account by running the following command. You w
 docker exec -it linkace_app_1 php artisan registeruser
 ```
 
+Lastly, change 'SETUP_COMPLETED=false' to 'SETUP_COMPLETED=true' in your `.env` file.
+
 You can now open LinkAce in your browser and should be able to use the application.
 
 {{< alert type="warning" >}}
@@ -68,8 +70,6 @@ After that, generate a new admin account by running the following command. You w
 ```
 php artisan registeruser
 ```
-
-Lastly, change 'SETUP_COMPLETED=false' to 'SETUP_COMPLETED=true' in your `.env` file.
 
 You can now open LinkAce in your browser and should be able to use the application.
 


### PR DESCRIPTION
Line was inserted below **Setup without Docker** but should go **Setup with Docker** 
Not sure if it also should go below **Setup without Docker**?

Used quotes, but backticks are needed to display `SETUP_COMPLETED` strings as code, correct this too. 