### PR TITLE
Installation requirements: specify which PDO type

### DIFF
--- a/content/docs/v1/setup/setup-without-docker.md
+++ b/content/docs/v1/setup/setup-without-docker.md
@@ -15,7 +15,7 @@ The application was developed with being used with Docker in mind. All following
     * JSON
     * Mbstring
     * OpenSSL
-    * PDO
+    * PDO (with [a driver](https://www.php.net/manual/en/pdo.drivers.php) matching your database)
     * Tokenizer
     * XML
     * DOM


### PR DESCRIPTION
Related to https://github.com/Kovah/LinkAce/pull/706: update the dependency name here as well.

Come to think of it, why MySQL specifically actually? I'm using SQLite for example, but the requirements checker still verifies that PDO MySQL is installed. Is that because that was the initially supported/tested database, or is some component always in use that depends on PDO MySQL?