### PR TITLE
Update Suppoted PHP versions

### DIFF
--- a/content/docs/v2/setup/setup-with-php.md
+++ b/content/docs/v2/setup/setup-with-php.md
@@ -11,7 +11,7 @@ Since this application was designed for Docker, consider the following steps as 
 * The `storage` directory inside LinkAce must be writable by the web server
 * The `bootstrap/cache` directory must be writable by the web server
 * The `.env` file must be writable by the web server during setup
-* **PHP 8.1 to 8.5**, with the following extensions
+* **PHP 8.2 to 8.5**, with the following extensions
     * BCMath
     * Ctype
     * DOM

--- a/content/docs/v2/setup/setup-with-php.md
+++ b/content/docs/v2/setup/setup-with-php.md
@@ -11,7 +11,7 @@ Since this application was designed for Docker, consider the following steps as 
 * The `storage` directory inside LinkAce must be writable by the web server
 * The `bootstrap/cache` directory must be writable by the web server
 * The `.env` file must be writable by the web server during setup
-* **PHP 8.1 to 8.4**, with the following extensions
+* **PHP 8.1 to 8.5**, with the following extensions
     * BCMath
     * Ctype
     * DOM


### PR DESCRIPTION
I am running LinkAce with PHP 8.5. I'm not sure if you want to "officially" support it, but everything seems fine in my low-volume install. 

This just bumps the supported PHP version to include 8.5 without changing the minimum version.